### PR TITLE
Remove dependency on rand crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "gravitation"
 version = "0.1.0"
 authors = ["Raphael Nestler <raphael.nestler@gmail.com>"]
 
-[dependencies]
+[dev-dependencies]
 rand = "0.3"
 
 [dev-dependencies.sdl2]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
-extern crate rand;
+extern crate core;
 
-use rand::Rng;
+mod random;
+
+use core::u32;
+
 
 #[derive(Clone)]
 pub struct Dimension {
@@ -37,11 +40,16 @@ pub struct World {
 }
 
 impl World {
-    pub fn new(width: u32, height: u32, star_count: u32) -> World {
-        let mut rng = rand::thread_rng();
+    pub fn new(width: u32, height: u32, star_count: u32,
+               prng_init: Option<(u32, u32, u32, u32)>) -> World {
         let mut stars = vec![];
+        let mut rng = match prng_init {
+            Some(init) => random::Xorshift128::init(init),
+            None => random::Xorshift128::new(),
+        };
         for _ in 0..star_count {
-            let (x, y) = rng.gen::<(f64, f64)>();
+            let x = rng.next() as f64 / u32::MAX as f64;
+            let y = rng.next() as f64 / u32::MAX as f64;
             let mut star = Star::new(width as f64 * x, height as f64 * y);
 
             star.speed.x = (star.position.y - (height as f64) / 2.0) / (height as f64 * 50.0);

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,0 +1,35 @@
+pub struct Xorshift128 {
+    x: u32,
+    y: u32,
+    z: u32,
+    w: u32,
+}
+
+impl Xorshift128 {
+    pub fn new() -> Self {
+        Xorshift128 {
+            x: 123456789,
+            y: 362436069,
+            z: 521288629,
+            w: 88675123,
+        }
+    }
+
+    pub fn init(init: (u32, u32, u32, u32)) -> Self {
+        Xorshift128 {
+            x: init.0,
+            y: init.1,
+            z: init.2,
+            w: init.3,
+        }
+    }
+
+    pub fn next(&mut self) -> u32 {
+          let t: u32 = self.x ^ (self.x << 11);
+          self.x = self.y;
+          self.y = self.z;
+          self.z = self.w;
+          self.w ^= (self.w >> 19) ^ t ^ (t >> 8);
+          self.w
+    }
+}


### PR DESCRIPTION
This gets rid of the last std dependency. The lib now works with libcore only.

The PR adds a simple Xorshift PRNG implementation: https://de.wikipedia.org/wiki/Xorshift